### PR TITLE
Test fixups

### DIFF
--- a/templates/s3-block-public-access/opa/test_policy.rego
+++ b/templates/s3-block-public-access/opa/test_policy.rego
@@ -2,6 +2,7 @@ package policy.tests
 
 import future.keywords
 
+import data.policy.deny
 
 mock_create := {
     "action": "CREATE",
@@ -19,32 +20,32 @@ with_properties(obj) = {"resource": {"properties": obj}}
 test_deny_if_not_public_access_blocked {
 	inp := object.union(mock_create, with_properties({
         "PublicAccessBlockConfiguration": {
-        	"BlockPublicAcls": false,
-            "BlockPublicPolicy": true,
-            "IgnorePublicAcls": true,
-            "RestrictPublicBuckets": false        
+        	"BlockPublicAcls": "false",
+            "BlockPublicPolicy": "true",
+            "IgnorePublicAcls": "true",
+            "RestrictPublicBuckets": "false",
         }
     }))
-    
+
     deny["public access not blocked for bucket MyS3Bucket"] with input as inp
 }
 
 test_allow_if_public_access_blocked {
 	inp := object.union(mock_create, with_properties({
         "PublicAccessBlockConfiguration": {
-        	"BlockPublicAcls": true,
-            "BlockPublicPolicy": true,
-            "IgnorePublicAcls": true,
-            "RestrictPublicBuckets": true        
+        	"BlockPublicAcls": "true",
+            "BlockPublicPolicy": "true",
+            "IgnorePublicAcls": "true",
+            "RestrictPublicBuckets": "true",
         }
     }))
-    
+
     count(deny) == 0 with input as inp
 }
 
-test_allow_if_excluded_suffix {
+test_allow_if_excluded_prefix {
 	count(deny) == 0 with input as object.union(mock_create, with_properties({
-    	"BucketName": "this-bucket-is-public"
+    	"BucketName": "excluded-bucket"
     }))
 }
 

--- a/templates/s3-bucket-encryption/opa/policy.rego
+++ b/templates/s3-bucket-encryption/opa/policy.rego
@@ -5,11 +5,19 @@ import future.keywords
 BucketEncryption := object.get(input.resource.properties, "BucketEncryption", "<undefined>")
 SSEAlgorithm := object.get(input.resource.properties.BucketEncryption.ServerSideEncryptionConfiguration[0].ServerSideEncryptionByDefault, "SSEAlgorithm", "<undefined>")
 
+bucket_encryption_unset {
+    BucketEncryption == "<undefined>"
+}
+
+bucket_encryption_unset {
+    BucketEncryption == {}
+}
+
 deny[msg] {
     input.action in {"CREATE", "UPDATE"}
     input.resource.type == "AWS::S3::Bucket"
 
-    BucketEncryption == "<undefined>"
+    bucket_encryption_unset
 
     msg := sprintf("bucket encryption is not enabled for bucket: %s", [input.resource.id])
 }

--- a/templates/s3-bucket-encryption/opa/test_policy.rego
+++ b/templates/s3-bucket-encryption/opa/test_policy.rego
@@ -2,6 +2,8 @@ package policy.tests
 
 import future.keywords
 
+import data.policy.deny
+
 mock_create := {
     "action": "CREATE",
     "hook": "Styra::OPA::Hook",
@@ -15,14 +17,11 @@ mock_create := {
 
 with_properties(obj) = {"resource": {"properties": obj}}
 
-# 1 fail if no encryption is set
-# 2 success with encryption 
-
 test_deny_if_bucket_encryption_not_set {
 	inp := object.union(mock_create, with_properties({
         "BucketEncryption": {}
     }))
-    
+
     deny["bucket encryption is not enabled for bucket: MyS3Bucket"] with input as inp
 }
 
@@ -33,10 +32,10 @@ test_allow_if_public_access_blocked {
                 {"ServerSideEncryptionByDefault": {
                     "SSEAlgorithm": "aws:kms"
                 } }
-            ]     
+            ]
         }
     }))
-    
+
     count(deny) == 0 with input as inp
 }
 

--- a/templates/s3-bucket-logging-enabled/opa/policy.rego
+++ b/templates/s3-bucket-logging-enabled/opa/policy.rego
@@ -4,14 +4,12 @@ import future.keywords
 
 s3BucketName := object.get(input.resource.properties, "BucketName", "")
 
-expectedLoggingPrefix = name {
+expectedLoggingPrefix = concat("-", ["s3-logs", s3BucketName]) {
 	s3BucketName != ""
-	name = concat("-", ["s3-logs", s3BucketName])
 }
 
-expectedLoggingPrefix = name {
+expectedLoggingPrefix = "s3-logs" {
 	s3BucketName == ""
-	name = "s3-logs"
 }
 
 expectedDestinationBucketName := "my-logging-bucket"

--- a/templates/s3-bucket-logging-enabled/opa/test_policy.rego
+++ b/templates/s3-bucket-logging-enabled/opa/test_policy.rego
@@ -2,6 +2,8 @@ package policy.tests
 
 import future.keywords
 
+import data.policy.deny
+
 mock_create := {
     "action": "CREATE",
     "hook": "Styra::OPA::Hook",
@@ -15,14 +17,11 @@ mock_create := {
 
 with_properties(obj) = {"resource": {"properties": obj}}
 
-# 1 fail if no encryption is set
-# 2 success with encryption 
-
 test_deny_if_bucket_encryption_not_set {
 	inp := object.union(mock_create, with_properties({
         "BucketEncryption": {}
     }))
-    
+
     deny["bucket encryption is not enabled for bucket: MyS3Bucket"] with input as inp
 }
 
@@ -33,10 +32,10 @@ test_allow_if_public_access_blocked {
                 {"ServerSideEncryptionByDefault": {
                     "SSEAlgorithm": "aws:kms"
                 } }
-            ]     
+            ]
         }
     }))
-    
+
     count(deny) == 0 with input as inp
 }
 

--- a/templates/security-group-open-ingress/opa/test_policy.rego
+++ b/templates/security-group-open-ingress/opa/test_policy.rego
@@ -1,3 +1,8 @@
+package policy.tests
+
+import future.keywords
+
+import data.policy.deny
 
 mock_create := {
     "action": "CREATE",
@@ -21,7 +26,7 @@ test_deny_if_security_group_allows_all_destinations {
             }
         ]
     }))
-    
+
     deny["Security Group cannot contain rules allow all destinations (0.0.0.0/0 or ::/0): SecurityGroup"] with input as inp
 }
 


### PR DESCRIPTION
Some fixes to run the tests. The one problem remaining is
the tests in the `s3-bucket-logging-enabled` directory, as
these seem to be copy-pasted from the bucket-encryption dir.

Signed-off-by: Anders Eknert <anders@eknert.com>