### PR TITLE
add timeout to OPA query

### DIFF
--- a/hooks/src/styra_opa_hook/handlers.py
+++ b/hooks/src/styra_opa_hook/handlers.py
@@ -74,7 +74,7 @@ def opa_query(
         headers = {"Authorization": f"Bearer {token}"}
 
     try:
-        resp = requests.post(type_configuration.opaUrl, json=opa_input, headers=headers)
+        resp = requests.post(type_configuration.opaUrl, json=opa_input, headers=headers, timeout=10)
     except requests.ConnectionError:
         LOG.error("Failed connecting to OPA at %s", type_configuration.opaUrl)
         progress.status = OperationStatus.FAILED

--- a/hooks/src/styra_opa_hook/handlers.py
+++ b/hooks/src/styra_opa_hook/handlers.py
@@ -74,11 +74,15 @@ def opa_query(
         headers = {"Authorization": f"Bearer {token}"}
 
     try:
-        resp = requests.post(type_configuration.opaUrl, json=opa_input, headers=headers, timeout=10)
+        connect_timeout = 10 
+        resp = requests.post(type_configuration.opaUrl, json=opa_input, headers=headers, timeout=connect_timeout)
+    except requests.exceptions.ConnectTimeout:
+        LOG.error("Timeout connecting to OPA at %s in %s seconds", type_configuration.opaUrl, connect_timeout)
+        progress.status = OperationStatus.FAILED
+        return progress
     except requests.ConnectionError:
         LOG.error("Failed connecting to OPA at %s", type_configuration.opaUrl)
         progress.status = OperationStatus.FAILED
-
         return progress
 
     if resp.status_code == 200:


### PR DESCRIPTION
In the situation where OPA is unreachable, this post will just hang and cloudformation will fail the hook after 30 seconds. This causes the hook logs in cloudwatch to end at `Hook triggered for target...`.

Adding a timeout allows the post to fail and properly log the failed connection. Happy to make it a different value but 10 seconds seemed reasonable. 