### PR TITLE
Add workflow to generate hook zip file

### DIFF
--- a/.github/workflows/generate-assets.yaml
+++ b/.github/workflows/generate-assets.yaml
@@ -25,20 +25,8 @@ jobs:
         pip install --quiet cloudformation-cli cloudformation-cli-python-plugin
         cfn submit --dry-run
 
-    - name: Git diff
-      id: git_diff
-      run: |
-        FILE_CHANGED=true
-        if ! git diff --no-ext-diff --quiet --exit-code; then
-          FILE_CHANGED=false
-        fi
-        echo "::set-output name=git_changes::$(echo $FILE_CHANGED)"
-
-    - name: Commit changes if any
-      if: steps.git_diff.outputs.git_changes
-      run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git add hooks/styra-opa-hook.zip
-        git commit -m "automation: update hook zip file"
-        git push
+    - name: Upload zip file as artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: hook-package-zip
+        path: hooks/styra-opa-hook.zip

--- a/.github/workflows/generate-assets.yaml
+++ b/.github/workflows/generate-assets.yaml
@@ -1,0 +1,44 @@
+name: Generate Assets
+
+on:
+  workflow_run:
+    workflows: [OPA Tests]
+    types:
+      - completed
+
+jobs:
+  opa-unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@v3
+
+    - name: Setup python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3
+
+    - name: Install and run cfn cli
+      run: |
+        cd hooks
+        pip install --quiet cloudformation-cli cloudformation-cli-python-plugin
+        cfn submit --dry-run
+
+    - name: Git diff
+      id: git_diff
+      run: |
+        FILE_CHANGED=true
+        if ! git diff --no-ext-diff --quiet --exit-code; then
+          FILE_CHANGED=false
+        fi
+        echo "::set-output name=git_changes::$(echo $FILE_CHANGED)"
+
+    - name: Commit changes if any
+      if: steps.git_diff.outputs.git_changes
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add hooks/styra-opa-hook.zip
+        git commit -m "automation: update hook zip file"
+        git push

--- a/.github/workflows/generate-assets.yaml
+++ b/.github/workflows/generate-assets.yaml
@@ -1,4 +1,4 @@
-name: Generate Assets
+name: Generate Zip File
 
 on:
   workflow_run:
@@ -7,7 +7,7 @@ on:
       - completed
 
 jobs:
-  opa-unit-tests:
+  generate-zip-file:
     runs-on: ubuntu-latest
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dmypy.json
 sam-tests/
 
 rpdk.log*
+
+*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -131,5 +131,3 @@ dmypy.json
 sam-tests/
 
 rpdk.log*
-
-*.zip


### PR DESCRIPTION
## Description

Use GitHub actions to generate the pre-compiled zip file for the hook. Users can then upload the zip file to S3 and use it as the schema handler package input when registering the hook in their account.

Solves https://github.com/StyraInc/opa-aws-cloudformation-hook/issues/40:
For users who do not have Docker Desktop installed locally due to licensing issues, the `cfn submit` command cannot be run with the default Docker flow. Disabling the Docker option in the hook configuration and building the zip file on a non-Linux system results in Lambda function errors. By running the `cfn submit --dry-run` command on an Ubuntu GitHub runner with Docker installed, we can ensure the hook package is correctly generated to run in Lambda.

## Changes

- Remove .zip from gitignore
- Add GitHub workflow to run after OPA Tests complete on push to generate the hook zip file

## Further Thoughts

Saving the zip file directly to the repo is not ideal, as it is nearly 90MB. We should instead move this process to use GitHub releases, however this solves an immediate pain point for non-Linux users without Docker Desktop.