### PR TITLE
Update hook config for clarity

### DIFF
--- a/hooks/styra-opa-hook-configuration.json
+++ b/hooks/styra-opa-hook-configuration.json
@@ -1,11 +1,11 @@
 {
     "properties": {
         "opaUrl": {
-            "description": "URL pointing to an OPA agent for policy decisions",
+            "description": "URL pointing to an OPA instance for policy decisions",
             "type": "string"
         },
         "opaAuthTokenSecret": {
-            "description": "ARN referencing a Secret in Secrets Manager containing a plain-text string token to use for authenticating against the OPA agent",
+            "description": "ARN referencing a Secret in Secrets Manager containing a plain-text string token to use for authenticating against the OPA instance",
             "type": "string"
         }
     },

--- a/hooks/styra-opa-hook-configuration.json
+++ b/hooks/styra-opa-hook-configuration.json
@@ -1,11 +1,11 @@
 {
     "properties": {
         "opaUrl": {
-            "description": "URL pointing to OPA for policy decisions",
+            "description": "URL pointing to an OPA agent for policy decisions",
             "type": "string"
         },
         "opaAuthTokenSecret": {
-            "description": "ARN referencing a secret containing a token to use for authenticating against OPA (secret key must be 'opa_auth_token')",
+            "description": "ARN referencing a Secret in Secrets Manager containing a plain-text string token to use for authenticating against the OPA agent",
             "type": "string"
         }
     },

--- a/hooks/styra-opa-hook.json
+++ b/hooks/styra-opa-hook.json
@@ -2107,11 +2107,11 @@
     "additionalProperties": false,
     "properties": {
       "opaAuthTokenSecret": {
-        "description": "ARN referencing a Secret in Secrets Manager containing a plain-text string token to use for authenticating against the OPA agent",
+        "description": "ARN referencing a Secret in Secrets Manager containing a plain-text string token to use for authenticating against the OPA instance",
         "type": "string"
       },
       "opaUrl": {
-        "description": "URL pointing to an OPA agent for policy decisions",
+        "description": "URL pointing to an OPA instance for policy decisions",
         "type": "string"
       }
     },

--- a/hooks/styra-opa-hook.json
+++ b/hooks/styra-opa-hook.json
@@ -1,6 +1,6 @@
 {
   "additionalProperties": false,
-  "description": "Hook to call out to Open Policy Agent",
+  "description": "Hook to call out to Open Policy Agent for policy decisions",
   "documentationUrl": "https://www.openpolicyagent.org/docs/latest/aws-cloudformation-hooks/",
   "handlers": {
     "preCreate": {
@@ -2107,11 +2107,11 @@
     "additionalProperties": false,
     "properties": {
       "opaAuthTokenSecret": {
-        "description": "ARN referencing a secret containing a token to use for authenticating against OPA (secret key must be 'opa_auth_token')",
+        "description": "ARN referencing a Secret in Secrets Manager containing a plain-text string token to use for authenticating against the OPA agent",
         "type": "string"
       },
       "opaUrl": {
-        "description": "URL pointing to OPA for policy decisions",
+        "description": "URL pointing to an OPA agent for policy decisions",
         "type": "string"
       }
     },


### PR DESCRIPTION
## Description

In issue https://github.com/StyraInc/opa-aws-cloudformation-hook/issues/35 it was brought up that the description for the `opaAuthTokenSecret` input was confusing, as it references a string value that was not needed. This PR updates the descriptions for both inputs as well as the hook description for clarity.

## Changes

- Update hook description in config
- Update descriptions for both hook inputs