### PR TITLE
Regal: ignore `rule-name-repeats-package`

### DIFF
--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -12,6 +12,8 @@ rules:
     line-length:
       level: error
       non-breakable-word-threshold: 80
+    rule-name-repeats-package:
+      level: ignore
   testing:
     print-or-trace-call:
       level: error


### PR DESCRIPTION
I don't think we should be changing names of these examples, so let's just ignore this rule for the time being.